### PR TITLE
Add retry mechanism for file download to help with flaky connections

### DIFF
--- a/git-bin/Remotes/S3Remote.cs
+++ b/git-bin/Remotes/S3Remote.cs
@@ -169,6 +169,8 @@ namespace GitBin.Remotes
                     {
                         // Ignore this exception and allow retry mechanism to take place
                     }
+
+                    attemptCount++;
                 }
 
                 throw new ಠ_ಠ(String.Format("File could not be successfully download after {0} attempts: {1}", attemptMax, fileName));


### PR DESCRIPTION
On my flaky connection in my Ubuntu and Mac VMs, I had to keep retrying the checkout because it was erroring out all the time.

I added a retry mechanism now everything is hunky-dory.
